### PR TITLE
Add option to clear junk models in tag table.

### DIFF
--- a/Taggable.php
+++ b/Taggable.php
@@ -37,6 +37,10 @@ class Taggable extends Behavior
      * @var string
      */
     public $relation = 'tags';
+    /**
+     * @var boolean
+     */
+    public $enableClearJunk = false;
 
     /**
      * @inheritdoc
@@ -152,5 +156,12 @@ class Taggable extends Behavior
             ->createCommand()
             ->delete($pivot, [key($relation->via->link) => $this->owner->getPrimaryKey()])
             ->execute();
+
+        if ($this->enableClearJunk) {
+            $this->owner->getDb()
+                ->createCommand()
+                ->delete($class::tableName(), $this->frequency . ' = 0')
+                ->execute();
+        }
     }
 }


### PR DESCRIPTION
If "enableClearJunk" is true, after editing/deleting owner model, tag records with a
frequency equal to zero will be removed. Default to false.