### PR TITLE
Your version may not work with another option of organizing relations between models.

### DIFF
--- a/Taggable.php
+++ b/Taggable.php
@@ -79,7 +79,7 @@ class Taggable extends Behavior
      */
     public function canGetProperty($name, $checkVars = true)
     {
-        return $name == $this->attribute ?: parent::canGetProperty($name, $checkVars);
+        return $name == $this->attribute ? : parent::canGetProperty($name, $checkVars);
     }
 
     /**
@@ -88,7 +88,7 @@ class Taggable extends Behavior
      */
     public function canSetProperty($name, $checkVars = true)
     {
-        return $name == $this->attribute ?: parent::canSetProperty($name, $checkVars);
+        return $name == $this->attribute ? : parent::canSetProperty($name, $checkVars);
     }
 
     /**
@@ -97,7 +97,7 @@ class Taggable extends Behavior
     public function __get($name)
     {
         if ($name == $this->attribute) {
-            return $this->getTagNames();
+            return $this->tagValues ? : $this->getTagNames();
         } else {
             return parent::__get($name);
         }
@@ -124,6 +124,9 @@ class Taggable extends Behavior
         return $this->asArray ? $items : implode(',', $items);
     }
 
+    /**
+     * @return ActiveRecord[]
+     */
     private function getOldTags()
     {
         if ($this->_old_tags === null) {
@@ -145,18 +148,9 @@ class Taggable extends Behavior
             }
         }
 
-        $names = array_unique(preg_split(
-            '/\s*,\s*/u',
-            preg_replace(
-                '/\s+/u',
-                ' ',
-                is_array($this->tagValues)
-                    ? implode(',', $this->tagValues)
-                    : $this->tagValues
-            ),
-            -1,
-            PREG_SPLIT_NO_EMPTY
-        ));
+        $value = is_array($this->tagValues) ? $this->tagValues : explode(',', $this->tagValues);
+        $value = array_map('trim', $value);
+        $names = array_unique($value);
 
         $old = $this->getOldTags();
         $new = array_flip($names);
@@ -187,9 +181,7 @@ class Taggable extends Behavior
 
     public function beforeDelete()
     {
-        foreach ($this->getOldTags() as $tag) {
-            $this->unlink($tag);
-        }
+        $this->owner->unlinkAll($this->relation, true);
     }
 
     /**

--- a/Taggable.php
+++ b/Taggable.php
@@ -26,7 +26,7 @@ class Taggable extends Behavior
     /**
      * @var string
      */
-    public $name = 'name';
+    public $relationAttribute = 'name';
     /**
      * @var string
      */
@@ -132,7 +132,7 @@ class Taggable extends Behavior
         if ($this->_old_tags === null) {
             $this->_old_tags = $this->owner
                 ->getRelation($this->relation)
-                ->indexBy($this->name)
+                ->indexBy($this->relationAttribute)
                 ->all();
         }
         return $this->_old_tags;
@@ -163,7 +163,7 @@ class Taggable extends Behavior
         $class = $this->owner->getRelation($this->relation)->modelClass;
 
         foreach ($create as $name => $key) {
-            $condition = [$this->name => $name];
+            $condition = [$this->relationAttribute => $name];
             $tag = $class::findOne($condition) ?: (new $class($condition));
             $this->link($tag);
         }

--- a/Taggable.php
+++ b/Taggable.php
@@ -150,10 +150,11 @@ class Taggable extends Behavior
 
         $value = is_array($this->tagValues) ? $this->tagValues : explode(',', $this->tagValues);
         $value = array_map('trim', $value);
-        $names = array_unique($value);
+        $value = array_unique($value);
+        $value = array_filter($value);
 
         $old = $this->getOldTags();
-        $new = array_flip($names);
+        $new = array_flip($value);
 
         $update = array_intersect_key($old, $new);
         $delete = array_diff_key($old, $update);

--- a/Taggable.php
+++ b/Taggable.php
@@ -45,6 +45,10 @@ class Taggable extends Behavior
      */
     public $asArray = false;
     /**
+     * @var bool
+     */
+    public $enableClearJunk = true;
+    /**
      * @var null|array
      */
     private $_old_tags;
@@ -191,7 +195,11 @@ class Taggable extends Behavior
     protected function unlink($tag)
     {
         $tag->{$this->frequency}--;
-        $tag->update();
+        if ($this->enableClearJunk && $tag->{$this->frequency} == 0) {
+            $tag->delete();
+        } else {
+            $tag->update();
+        }
         $this->owner->unlink($this->relation, $tag, true);
     }
 }

--- a/Taggable.php
+++ b/Taggable.php
@@ -112,7 +112,7 @@ class Taggable extends Behavior
      */
     private function getTagNames()
     {
-        $items = array_keys($this->getOldTags());
+        $items = $this->owner->isNewRecord ? [] : array_keys($this->getOldTags());
         return $this->asArray ? $items : implode(', ', $items);
     }
 

--- a/Taggable.php
+++ b/Taggable.php
@@ -64,13 +64,11 @@ class Taggable extends Behavior
 
     /**
      * @inheritdoc
+     * @return bool
      */
     public function canGetProperty($name, $checkVars = true)
     {
-        if ($name == $this->attribute) {
-            return true;
-        }
-        return parent::canGetProperty($name, $checkVars);
+        return $name == $this->attribute ?: parent::canGetProperty($name, $checkVars);
     }
 
     /**
@@ -80,22 +78,19 @@ class Taggable extends Behavior
     {
         if ($name == $this->attribute) {
             return $this->getTagNames();
+        } else {
+            return parent::__get($name);
         }
-
-        return parent::__get($name);
     }
 
     /**
      * @inheritdoc
+     * @return bool
      */
     public function canSetProperty($name, $checkVars = true)
     {
-        if ($name == $this->attribute) {
-            return true;
-        }
-        return parent::canSetProperty($name, $checkVars);
+        return $name == $this->attribute ?: parent::canSetProperty($name, $checkVars);
     }
-
 
     /**
      * @inheritdoc
@@ -104,10 +99,9 @@ class Taggable extends Behavior
     {
         if ($name == $this->attribute) {
             $this->tagValues = $value;
-            return ;
+        } else {
+            parent::__set($name, $value);
         }
-
-        parent::__set($name, $value);
     }
 
     /**
@@ -129,10 +123,10 @@ class Taggable extends Behavior
     public function afterSave($event)
     {
         if ($this->tagValues === null) {
-            if($this->owner->{$this->attribute} !== null) {
+            if ($this->owner->{$this->attribute} !== null) {
                 $this->tagValues = $this->owner->{$this->attribute};
             } else {
-                return;   
+                return;
             }
         }
 


### PR DESCRIPTION
Your version may not work with another option of organizing relations between models.
```php
/**
 * @return \yii\db\ActiveQuery
 */
public function getPageTag()
{
    return $this->hasMany(PageTag::className(), ['page_id' => 'id'])
}

/**
 * @return \yii\db\ActiveQuery
 */
public function getTags()
{
    return $this->hasMany(Tag::className(), ['id' => 'tag_id'])
        //->viaTable('page_tag', ['page_id' => 'id']);
        ->via('pageTags');
}
```

Why remove all the connections and then to recreate them, if you can logically determine which connection it is necessary to remove and what to add.
```php
    $update = array_intersect_key($old, $new);
    $delete = array_diff_key($old, $update);
    $create = array_diff_key($new, $update);
```

To create and delete a link to another model, there is a standard ActiveRecord methods
```php
    $this->owner->link($this->relation, $tag);
    $this->owner->unlink($this->relation, $tag, true);
```