### PR TITLE
Remove unused tags

### DIFF
--- a/src/Taggable.php
+++ b/src/Taggable.php
@@ -35,6 +35,10 @@ class Taggable extends Behavior
      */
     public $frequency = 'frequency';
     /**
+     * @var bool
+     */
+    public $removeUnusedTags = false;
+    /**
      * @var string
      */
     public $relation = 'tags';
@@ -201,5 +205,10 @@ class Taggable extends Behavior
             ->createCommand()
             ->delete($pivot, [key($relation->via->link) => $this->owner->getPrimaryKey()])
             ->execute();
+        
+        if ($this->removeUnusedTags)
+        {
+            $class::deleteAll([$this->frequency => 0]);
+        }
     }
 }


### PR DESCRIPTION
Added an option to delete tags that have a frequency of zero. Useful, for instance, if you want to list all the tags in the database without needing to explicitly exclude unused tags.